### PR TITLE
전체 Gradle Test에서 깨지던 MemberServiceTest 수정

### DIFF
--- a/src/test/java/com/windstorm/management/service/cell/CellServiceTest.java
+++ b/src/test/java/com/windstorm/management/service/cell/CellServiceTest.java
@@ -44,6 +44,7 @@ class CellServiceTest {
 	void cleanUp() {
 		cellRepository.deleteAll();
 		unitRepository.deleteAll();
+		memberRepository.deleteAll();
 	}
 
 	@Test


### PR DESCRIPTION
### 수정사항
- CellService에서 Member를 저장하고나서 cleanup 해주지 않아서 MemberServiceTest에 영향을 가는 것을 수정