### PR TITLE
생성시간, 수정시간 DB에 표시되도록 수정

### DIFF
--- a/src/main/java/com/windstorm/management/ManagementApplication.java
+++ b/src/main/java/com/windstorm/management/ManagementApplication.java
@@ -2,8 +2,10 @@ package com.windstorm.management;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class ManagementApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/windstorm/management/api/user/cell/response/CellResponse.java
+++ b/src/main/java/com/windstorm/management/api/user/cell/response/CellResponse.java
@@ -1,5 +1,7 @@
 package com.windstorm.management.api.user.cell.response;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -12,6 +14,9 @@ import lombok.Builder;
 
 @Builder
 public record CellResponse(
+	Long id,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt,
 	String name,
 	List<MemberResponse> members
 ) {
@@ -24,6 +29,9 @@ public record CellResponse(
 		setCaptainFirstInList(members);
 
 		return CellResponse.builder()
+			.id(cell.getId())
+			.createdAt(cell.getCreatedAt())
+			.modifiedAt(cell.getModifiedAt())
 			.name(cell.getName())
 			.members(members)
 			.build();

--- a/src/main/java/com/windstorm/management/api/user/member/response/MemberResponse.java
+++ b/src/main/java/com/windstorm/management/api/user/member/response/MemberResponse.java
@@ -1,6 +1,7 @@
 package com.windstorm.management.api.user.member.response;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 
 import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.domain.global.Gender;
@@ -12,6 +13,8 @@ import lombok.Builder;
 @Builder
 public record MemberResponse(
 	Long id,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt,
 	String uniqueMemberId,
 	String name,
 	String cellName,
@@ -27,6 +30,8 @@ public record MemberResponse(
 	public static MemberResponse toResponse(Member member) {
 		return MemberResponse.builder()
 			.id(member.getId())
+			.createdAt(member.getCreatedAt())
+			.modifiedAt(member.getModifiedAt())
 			.uniqueMemberId(member.getUniqueId())
 			.name(member.getName())
 			.cellName(member.getCell() == null ? "새가족" : member.getCell().getName())

--- a/src/main/java/com/windstorm/management/api/user/unit/response/UnitResponse.java
+++ b/src/main/java/com/windstorm/management/api/user/unit/response/UnitResponse.java
@@ -1,5 +1,6 @@
 package com.windstorm.management.api.user.unit.response;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 import com.windstorm.management.api.user.cell.response.CellResponse;
@@ -10,6 +11,9 @@ import lombok.Builder;
 
 @Builder
 public record UnitResponse(
+	Long id,
+	LocalDateTime createdAt,
+	LocalDateTime modifiedAt,
 	Division division,
 	String name,
 	String managerName,
@@ -22,6 +26,9 @@ public record UnitResponse(
 			.toList();
 
 		return UnitResponse.builder()
+			.id(unit.getId())
+			.createdAt(unit.getCreatedAt())
+			.modifiedAt(unit.getModifiedAt())
 			.division(unit.getDivision())
 			.name(unit.getName())
 			.managerName(unit.getName().substring(0, 3))

--- a/src/main/java/com/windstorm/management/domain/BaseTimeEntity.java
+++ b/src/main/java/com/windstorm/management/domain/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.windstorm.management.domain;
+
+import java.time.LocalDateTime;
+
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+	@CreatedDate
+	private LocalDateTime createdAt;
+
+	@LastModifiedDate
+	private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/windstorm/management/domain/cell/Cell.java
+++ b/src/main/java/com/windstorm/management/domain/cell/Cell.java
@@ -3,6 +3,7 @@ package com.windstorm.management.domain.cell;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.windstorm.management.domain.BaseTimeEntity;
 import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.domain.member.Member;
 import com.windstorm.management.domain.unit.Unit;
@@ -25,7 +26,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-public class Cell {
+public class Cell extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/windstorm/management/domain/member/Member.java
+++ b/src/main/java/com/windstorm/management/domain/member/Member.java
@@ -7,6 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.windstorm.management.api.admin.member.request.MemberModify;
 import com.windstorm.management.api.user.member.request.PasswordModify;
+import com.windstorm.management.domain.BaseTimeEntity;
 import com.windstorm.management.domain.cell.Cell;
 import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.domain.global.Gender;
@@ -29,7 +30,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends BaseTimeEntity {
 
 	private static final int ORIGIN_YEAR = 1972;
 

--- a/src/main/java/com/windstorm/management/domain/unit/Unit.java
+++ b/src/main/java/com/windstorm/management/domain/unit/Unit.java
@@ -3,6 +3,7 @@ package com.windstorm.management.domain.unit;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.windstorm.management.domain.BaseTimeEntity;
 import com.windstorm.management.domain.cell.Cell;
 import com.windstorm.management.domain.global.Division;
 
@@ -22,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Unit {
+public class Unit extends BaseTimeEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)


### PR DESCRIPTION
### 추가사항
- DB에 데이터 새로 데이터가 입력되거나 기존 데이터의 수정이 완료됐을 시 생성시간 및 수정시간을 추적하도록 BaseTimeEntity 추가
- 각 Domain 클래스가 BaseTimeEntity를 상속하도록 변경
- Api Response가 id 및 생성시간, 수정시간을 나타내도록 수정