### PR TITLE
Admin에서 청년부(Division) 정보가 필요한 몇 가지 기능에 대하여 수정

### DIFF
--- a/src/main/java/com/windstorm/management/api/admin/cell/request/CellAddMember.java
+++ b/src/main/java/com/windstorm/management/api/admin/cell/request/CellAddMember.java
@@ -1,12 +1,18 @@
 package com.windstorm.management.api.admin.cell.request;
 
+import com.windstorm.management.domain.global.Division;
+
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 @Builder
 public record CellAddMember(
 	@NotBlank(message = "셀 이름을 입력해주세요.")
 	String cellName,
+
+	@NotNull(message = "청년부를 입력해주세요.")
+	Division division,
 
 	@NotBlank(message = "셀원 교적번호를 입력해주세요.")
 	String uniqueId

--- a/src/main/java/com/windstorm/management/api/admin/cell/request/CellAddMember.java
+++ b/src/main/java/com/windstorm/management/api/admin/cell/request/CellAddMember.java
@@ -14,7 +14,7 @@ public record CellAddMember(
 	@NotNull(message = "청년부를 입력해주세요.")
 	Division division,
 
-	@NotBlank(message = "셀원 교적번호를 입력해주세요.")
+	@NotBlank(message = "새롭게 추가할 청년의 교적번호를 입력해주세요.")
 	String uniqueId
 ) {
 }

--- a/src/main/java/com/windstorm/management/api/admin/member/request/MemberCellModify.java
+++ b/src/main/java/com/windstorm/management/api/admin/member/request/MemberCellModify.java
@@ -1,10 +1,13 @@
 package com.windstorm.management.api.admin.member.request;
 
+import com.windstorm.management.domain.global.Division;
+
 import lombok.Builder;
 
 @Builder
 public record MemberCellModify(
 	String uniqueId,
-	String cellName
+	String cellName,
+	Division division
 ) {
 }

--- a/src/main/java/com/windstorm/management/implement/cell/CellManager.java
+++ b/src/main/java/com/windstorm/management/implement/cell/CellManager.java
@@ -20,7 +20,7 @@ public class CellManager {
 	@Transactional
 	public void addMember(CellAddMember request) {
 		Member member = memberReader.read(request.uniqueId());
-		Cell cell = cellReader.read(request.cellName(), request.division());
+		Cell cell = cellReader.readWithDivision(request.cellName(), request.division());
 
 		cell.addMember(member);
 	}

--- a/src/main/java/com/windstorm/management/implement/cell/CellManager.java
+++ b/src/main/java/com/windstorm/management/implement/cell/CellManager.java
@@ -20,7 +20,7 @@ public class CellManager {
 	@Transactional
 	public void addMember(CellAddMember request) {
 		Member member = memberReader.read(request.uniqueId());
-		Cell cell = cellReader.read(request.cellName());
+		Cell cell = cellReader.read(request.cellName(), request.division());
 
 		cell.addMember(member);
 	}

--- a/src/main/java/com/windstorm/management/implement/cell/CellReader.java
+++ b/src/main/java/com/windstorm/management/implement/cell/CellReader.java
@@ -4,6 +4,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.windstorm.management.domain.cell.Cell;
+import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.repository.cell.CellRepository;
 
 import lombok.RequiredArgsConstructor;
@@ -14,7 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class CellReader {
 	private final CellRepository cellRepository;
 
-	public Cell read(String name) {
-		return cellRepository.findByName(name).orElseThrow(() -> new RuntimeException(name + "에 해당하는 셀이 존재하지 않습니다."));
+	public Cell read(String name, Division division) {
+		return cellRepository.findByNameAndDivision(name, division).orElseThrow(() -> new RuntimeException(name + "에 해당하는 셀이 존재하지 않습니다."));
 	}
 }

--- a/src/main/java/com/windstorm/management/implement/cell/CellReader.java
+++ b/src/main/java/com/windstorm/management/implement/cell/CellReader.java
@@ -15,7 +15,13 @@ import lombok.RequiredArgsConstructor;
 public class CellReader {
 	private final CellRepository cellRepository;
 
-	public Cell read(String name, Division division) {
-		return cellRepository.findByNameAndDivision(name, division).orElseThrow(() -> new RuntimeException(name + "에 해당하는 셀이 존재하지 않습니다."));
+	public Cell read(String name) {
+		return cellRepository.findByName(name)
+			.orElseThrow(() -> new RuntimeException(name + "에 해당하는 셀이 존재하지 않습니다."));
+	}
+
+	public Cell readWithDivision(String name, Division division) {
+		return cellRepository.findByNameAndDivision(name, division)
+			.orElseThrow(() -> new RuntimeException(name + "에 해당하는 셀이 존재하지 않습니다."));
 	}
 }

--- a/src/main/java/com/windstorm/management/repository/cell/CellRepository.java
+++ b/src/main/java/com/windstorm/management/repository/cell/CellRepository.java
@@ -5,7 +5,8 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.windstorm.management.domain.cell.Cell;
+import com.windstorm.management.domain.global.Division;
 
 public interface CellRepository extends JpaRepository<Cell, Long> {
-	Optional<Cell> findByName(String name);
+	Optional<Cell> findByNameAndDivision(String name, Division division);
 }

--- a/src/main/java/com/windstorm/management/repository/cell/CellRepository.java
+++ b/src/main/java/com/windstorm/management/repository/cell/CellRepository.java
@@ -8,5 +8,6 @@ import com.windstorm.management.domain.cell.Cell;
 import com.windstorm.management.domain.global.Division;
 
 public interface CellRepository extends JpaRepository<Cell, Long> {
+	Optional<Cell> findByName(String name);
 	Optional<Cell> findByNameAndDivision(String name, Division division);
 }

--- a/src/main/java/com/windstorm/management/service/member/MemberService.java
+++ b/src/main/java/com/windstorm/management/service/member/MemberService.java
@@ -37,7 +37,7 @@ public class MemberService {
 	 */
 	public void modifyCell(MemberCellModify request) {
 		Member member = memberReader.read(request.uniqueId());
-		Cell newCell = cellReader.read(request.cellName());
+		Cell newCell = cellReader.readWithDivision(request.cellName(), request.division());
 		memberModifier.modifyCell(member, newCell);
 	}
 


### PR DESCRIPTION
### 변경 사항
- Admin 페이지에서 기능을 수행 시 셀을 조회하는 경우에 중복된 셀의 경우를 고려하여 셀을 조회할 때 셀 이름 뿐 아니라 소속 청년부까지 함께 조회하도록 하는 조건을 추가