### PR TITLE
심방 보고서 알림 기능

### DIFF
--- a/src/main/java/com/windstorm/management/api/admin/notification/AdminNotificationController.java
+++ b/src/main/java/com/windstorm/management/api/admin/notification/AdminNotificationController.java
@@ -1,0 +1,33 @@
+package com.windstorm.management.api.admin.notification;
+
+import java.util.List;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.windstorm.management.api.ApiResponse;
+import com.windstorm.management.api.admin.notification.response.NotificationResponse;
+import com.windstorm.management.infrastructure.security.UserPrincipal;
+import com.windstorm.management.service.notification.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class AdminNotificationController {
+	private final NotificationService notificationService;
+
+	@PreAuthorize("isAuthenticated() && hasAnyRole('PASTOR')")
+	@GetMapping()
+	public ApiResponse<List<NotificationResponse>> getNotifications(
+		@AuthenticationPrincipal UserPrincipal userPrincipal
+	) {
+		String uniqueId = userPrincipal.getUniqueId();
+		return ApiResponse.of(HttpStatus.OK, "알림 조회 성공", notificationService.getNotifications(uniqueId));
+	}
+}

--- a/src/main/java/com/windstorm/management/api/admin/notification/AdminNotificationController.java
+++ b/src/main/java/com/windstorm/management/api/admin/notification/AdminNotificationController.java
@@ -6,6 +6,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -29,5 +31,12 @@ public class AdminNotificationController {
 	) {
 		String uniqueId = userPrincipal.getUniqueId();
 		return ApiResponse.of(HttpStatus.OK, "알림 조회 성공", notificationService.getNotifications(uniqueId));
+	}
+
+	@PreAuthorize("isAuthenticated() && hasAnyRole('PASTOR')")
+	@PutMapping("/{id}")
+	public ApiResponse<Object> updateNotificationIsRead(@PathVariable Long id) {
+		notificationService.updateNotificationIsRead(id);
+		return ApiResponse.of(HttpStatus.OK, "미확인 알림 조회 상태 업데이트 성공", null);
 	}
 }

--- a/src/main/java/com/windstorm/management/api/admin/notification/AdminNotificationController.java
+++ b/src/main/java/com/windstorm/management/api/admin/notification/AdminNotificationController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,7 +21,7 @@ import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/notifications")
+@RequestMapping("/api/admin/notifications")
 public class AdminNotificationController {
 	private final NotificationService notificationService;
 
@@ -38,5 +39,12 @@ public class AdminNotificationController {
 	public ApiResponse<Object> updateNotificationIsRead(@PathVariable Long id) {
 		notificationService.updateNotificationIsRead(id);
 		return ApiResponse.of(HttpStatus.OK, "미확인 알림 조회 상태 업데이트 성공", null);
+	}
+
+	@PreAuthorize("isAuthenticated() && hasAnyRole('PASTOR')")
+	@DeleteMapping("/{id}")
+	public ApiResponse<Object> deleteNotification(@PathVariable Long id) {
+		notificationService.delete(id);
+		return ApiResponse.of(HttpStatus.OK, "알림 삭제 성공", null);
 	}
 }

--- a/src/main/java/com/windstorm/management/api/admin/notification/response/NotificationResponse.java
+++ b/src/main/java/com/windstorm/management/api/admin/notification/response/NotificationResponse.java
@@ -1,0 +1,19 @@
+package com.windstorm.management.api.admin.notification.response;
+
+import com.windstorm.management.domain.notification.Notification;
+
+import lombok.Builder;
+
+@Builder
+public record NotificationResponse(
+	long id,
+	String message
+) {
+
+	public static NotificationResponse toResponse(Notification notification) {
+		return NotificationResponse.builder()
+			.id(notification.getId())
+			.message(notification.getMessage())
+			.build();
+	}
+}

--- a/src/main/java/com/windstorm/management/domain/notification/Notification.java
+++ b/src/main/java/com/windstorm/management/domain/notification/Notification.java
@@ -1,0 +1,47 @@
+package com.windstorm.management.domain.notification;
+
+import com.windstorm.management.domain.BaseTimeEntity;
+import com.windstorm.management.domain.member.Member;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notification extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	private String message;
+
+	@ManyToOne
+	@JoinColumn(name = "member_id")
+	private Member member;
+
+	private boolean isRead;
+
+	@Builder
+	private Notification(String message, Member member) {
+		this.message = message;
+		this.member = member;
+		this.isRead = false;
+	}
+
+	public static Notification createNotification(String message, Member member) {
+		return Notification.builder()
+			.message(message)
+			.member(member)
+			.build();
+	}
+}

--- a/src/main/java/com/windstorm/management/domain/notification/Notification.java
+++ b/src/main/java/com/windstorm/management/domain/notification/Notification.java
@@ -44,4 +44,8 @@ public class Notification extends BaseTimeEntity {
 			.member(member)
 			.build();
 	}
+
+	public void updateIsRead() {
+		this.isRead = true;
+	}
 }

--- a/src/main/java/com/windstorm/management/implement/member/MemberReader.java
+++ b/src/main/java/com/windstorm/management/implement/member/MemberReader.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.domain.member.Member;
 import com.windstorm.management.repository.member.MemberRepository;
 
@@ -27,5 +28,9 @@ public class MemberReader {
 			throw new RuntimeException(name + "에 해당하는 데이터가 존재하지 않습니다.");
 		}
 		return members;
+	}
+
+	public Member findDivisionPastor(Division division) {
+		return memberRepository.findDivisionPastor(division);
 	}
 }

--- a/src/main/java/com/windstorm/management/implement/notification/NotificationAppender.java
+++ b/src/main/java/com/windstorm/management/implement/notification/NotificationAppender.java
@@ -1,0 +1,29 @@
+package com.windstorm.management.implement.notification;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.windstorm.management.domain.global.Division;
+import com.windstorm.management.domain.member.Member;
+import com.windstorm.management.domain.notification.Notification;
+import com.windstorm.management.implement.member.MemberReader;
+import com.windstorm.management.repository.notification.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationAppender {
+	private final NotificationRepository notificationRepository;
+	private final MemberReader memberReader;
+
+	@Transactional
+	public void append(String writerName, Division division) {
+		Member pastor = memberReader.findDivisionPastor(division);
+		Notification notification = Notification.createNotification(
+			writerName + " 청년이 심방 보고서를 작성했습니다.",
+			pastor
+		);
+		notificationRepository.save(notification);
+	}
+}

--- a/src/main/java/com/windstorm/management/implement/notification/NotificationModifier.java
+++ b/src/main/java/com/windstorm/management/implement/notification/NotificationModifier.java
@@ -13,8 +13,7 @@ public class NotificationModifier {
 	private final NotificationReader notificationReader;
 
 	@Transactional
-	public void updateIsRead(Long id) {
-		Notification notification = notificationReader.read(id);
+	public void updateIsRead(Notification notification) {
 		notification.updateIsRead();
 	}
 }

--- a/src/main/java/com/windstorm/management/implement/notification/NotificationModifier.java
+++ b/src/main/java/com/windstorm/management/implement/notification/NotificationModifier.java
@@ -1,0 +1,20 @@
+package com.windstorm.management.implement.notification;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.windstorm.management.domain.notification.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationModifier {
+	private final NotificationReader notificationReader;
+
+	@Transactional
+	public void updateIsRead(Long id) {
+		Notification notification = notificationReader.read(id);
+		notification.updateIsRead();
+	}
+}

--- a/src/main/java/com/windstorm/management/implement/notification/NotificationReader.java
+++ b/src/main/java/com/windstorm/management/implement/notification/NotificationReader.java
@@ -16,6 +16,11 @@ import lombok.RequiredArgsConstructor;
 public class NotificationReader {
 	private final NotificationRepository notificationRepository;
 
+	public Notification read(Long id) {
+		return notificationRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException(id + "에 해당하는 알림이 존재하지 않습니다."));
+	}
+
 	public List<Notification> readBy(Long id) {
 		return notificationRepository.findNotificationsByPastor(id);
 	}

--- a/src/main/java/com/windstorm/management/implement/notification/NotificationReader.java
+++ b/src/main/java/com/windstorm/management/implement/notification/NotificationReader.java
@@ -1,0 +1,22 @@
+package com.windstorm.management.implement.notification;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.windstorm.management.domain.notification.Notification;
+import com.windstorm.management.repository.notification.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationReader {
+	private final NotificationRepository notificationRepository;
+
+	public List<Notification> readBy(Long id) {
+		return notificationRepository.findNotificationsByPastor(id);
+	}
+}

--- a/src/main/java/com/windstorm/management/implement/notification/NotificationRemover.java
+++ b/src/main/java/com/windstorm/management/implement/notification/NotificationRemover.java
@@ -1,0 +1,20 @@
+package com.windstorm.management.implement.notification;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.windstorm.management.domain.notification.Notification;
+import com.windstorm.management.repository.notification.NotificationRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationRemover {
+	private final NotificationRepository notificationRepository;
+
+	@Transactional
+	public void delete(Notification notification) {
+		notificationRepository.delete(notification);
+	}
+}

--- a/src/main/java/com/windstorm/management/repository/member/MemberRepositoryCustom.java
+++ b/src/main/java/com/windstorm/management/repository/member/MemberRepositoryCustom.java
@@ -2,9 +2,12 @@ package com.windstorm.management.repository.member;
 
 import java.util.List;
 
+import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.domain.member.Member;
 
 public interface MemberRepositoryCustom {
 
 	List<Member> findAllByName(String name);
+
+	Member findDivisionPastor(Division division);
 }

--- a/src/main/java/com/windstorm/management/repository/member/MemberRepositoryCustomImpl.java
+++ b/src/main/java/com/windstorm/management/repository/member/MemberRepositoryCustomImpl.java
@@ -5,6 +5,8 @@ import static com.windstorm.management.domain.member.QMember.*;
 import java.util.List;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.windstorm.management.domain.global.Division;
+import com.windstorm.management.domain.global.LeaderRole;
 import com.windstorm.management.domain.member.Member;
 
 import lombok.RequiredArgsConstructor;
@@ -20,5 +22,13 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 			.where(member.name.eq(name))
 			.orderBy(member.id.asc())
 			.fetch();
+	}
+
+	@Override
+	public Member findDivisionPastor(Division division) {
+		return queryFactory
+			.selectFrom(member)
+			.where(member.division.eq(division).and(member.role.eq(LeaderRole.PASTOR)))
+			.fetchOne();
 	}
 }

--- a/src/main/java/com/windstorm/management/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/windstorm/management/repository/notification/NotificationRepository.java
@@ -4,5 +4,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.windstorm.management.domain.notification.Notification;
 
-public interface NotificationRepository extends JpaRepository<Notification, Long> {
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
 }

--- a/src/main/java/com/windstorm/management/repository/notification/NotificationRepository.java
+++ b/src/main/java/com/windstorm/management/repository/notification/NotificationRepository.java
@@ -1,0 +1,8 @@
+package com.windstorm.management.repository.notification;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.windstorm.management.domain.notification.Notification;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+}

--- a/src/main/java/com/windstorm/management/repository/notification/NotificationRepositoryCustom.java
+++ b/src/main/java/com/windstorm/management/repository/notification/NotificationRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.windstorm.management.repository.notification;
+
+import java.util.List;
+
+import com.windstorm.management.domain.notification.Notification;
+
+public interface NotificationRepositoryCustom {
+
+	List<Notification> findNotificationsByPastor(Long id);
+}

--- a/src/main/java/com/windstorm/management/repository/notification/NotificationRepositoryCustomImpl.java
+++ b/src/main/java/com/windstorm/management/repository/notification/NotificationRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.windstorm.management.repository.notification;
+
+import static com.windstorm.management.domain.notification.QNotification.*;
+
+import java.util.List;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.windstorm.management.domain.notification.Notification;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationRepositoryCustomImpl implements NotificationRepositoryCustom {
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Notification> findNotificationsByPastor(Long id) {
+		return queryFactory
+			.selectFrom(notification)
+			.where(notification.member.id.eq(id).and(notification.isRead.eq(false)))
+			.orderBy(notification.id.desc())
+			.fetch();
+	}
+}

--- a/src/main/java/com/windstorm/management/service/notification/NotificationService.java
+++ b/src/main/java/com/windstorm/management/service/notification/NotificationService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 import com.windstorm.management.api.admin.notification.response.NotificationResponse;
 import com.windstorm.management.domain.member.Member;
 import com.windstorm.management.implement.member.MemberReader;
+import com.windstorm.management.implement.notification.NotificationModifier;
 import com.windstorm.management.implement.notification.NotificationReader;
 
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class NotificationService {
 	private final NotificationReader notificationReader;
+	private final NotificationModifier notificationModifier;
 	private final MemberReader memberReader;
 
 	public List<NotificationResponse> getNotifications(String uniqueId) {
@@ -23,5 +25,9 @@ public class NotificationService {
 		return notificationReader.readBy(pastor.getId()).stream()
 			.map(NotificationResponse::toResponse)
 			.collect(Collectors.toList());
+	}
+
+	public void updateNotificationIsRead(Long id) {
+		notificationModifier.updateIsRead(id);
 	}
 }

--- a/src/main/java/com/windstorm/management/service/notification/NotificationService.java
+++ b/src/main/java/com/windstorm/management/service/notification/NotificationService.java
@@ -1,0 +1,27 @@
+package com.windstorm.management.service.notification;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+
+import com.windstorm.management.api.admin.notification.response.NotificationResponse;
+import com.windstorm.management.domain.member.Member;
+import com.windstorm.management.implement.member.MemberReader;
+import com.windstorm.management.implement.notification.NotificationReader;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+	private final NotificationReader notificationReader;
+	private final MemberReader memberReader;
+
+	public List<NotificationResponse> getNotifications(String uniqueId) {
+		Member pastor = memberReader.read(uniqueId);
+		return notificationReader.readBy(pastor.getId()).stream()
+			.map(NotificationResponse::toResponse)
+			.collect(Collectors.toList());
+	}
+}

--- a/src/main/java/com/windstorm/management/service/notification/NotificationService.java
+++ b/src/main/java/com/windstorm/management/service/notification/NotificationService.java
@@ -7,9 +7,11 @@ import org.springframework.stereotype.Service;
 
 import com.windstorm.management.api.admin.notification.response.NotificationResponse;
 import com.windstorm.management.domain.member.Member;
+import com.windstorm.management.domain.notification.Notification;
 import com.windstorm.management.implement.member.MemberReader;
 import com.windstorm.management.implement.notification.NotificationModifier;
 import com.windstorm.management.implement.notification.NotificationReader;
+import com.windstorm.management.implement.notification.NotificationRemover;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 public class NotificationService {
 	private final NotificationReader notificationReader;
 	private final NotificationModifier notificationModifier;
+	private final NotificationRemover notificationRemover;
 	private final MemberReader memberReader;
 
 	public List<NotificationResponse> getNotifications(String uniqueId) {
@@ -28,6 +31,12 @@ public class NotificationService {
 	}
 
 	public void updateNotificationIsRead(Long id) {
-		notificationModifier.updateIsRead(id);
+		Notification notification = notificationReader.read(id);
+		notificationModifier.updateIsRead(notification);
+	}
+
+	public void delete(Long id) {
+		Notification notification = notificationReader.read(id);
+		notificationRemover.delete(notification);
 	}
 }

--- a/src/main/java/com/windstorm/management/service/report/ReportService.java
+++ b/src/main/java/com/windstorm/management/service/report/ReportService.java
@@ -10,6 +10,7 @@ import com.windstorm.management.domain.global.Division;
 import com.windstorm.management.domain.member.Member;
 import com.windstorm.management.domain.report.Report;
 import com.windstorm.management.implement.member.MemberReader;
+import com.windstorm.management.implement.notification.NotificationAppender;
 import com.windstorm.management.implement.report.ReportAppender;
 import com.windstorm.management.implement.report.ReportModifier;
 import com.windstorm.management.implement.report.ReportReader;
@@ -23,10 +24,12 @@ public class ReportService {
 	private final ReportReader reportReader;
 	private final ReportModifier reportModifier;
 	private final MemberReader memberReader;
+	private final NotificationAppender notificationAppender;
 
 	public void append(String uniqueId, ReportCreate request) {
 		Member member = memberReader.read(uniqueId);
 		reportAppender.append(member, request);
+		notificationAppender.append(member.getName(), request.division());
 	}
 
 	public List<ReportResponse> getUnReadAllReports(Division division) {

--- a/src/test/java/com/windstorm/management/implement/notification/NotificationAppenderTest.java
+++ b/src/test/java/com/windstorm/management/implement/notification/NotificationAppenderTest.java
@@ -1,0 +1,42 @@
+package com.windstorm.management.implement.notification;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.windstorm.management.domain.global.Division;
+import com.windstorm.management.domain.notification.Notification;
+import com.windstorm.management.implement.member.MemberReader;
+import com.windstorm.management.repository.notification.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationAppenderTest {
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@Mock
+	private MemberReader memberReader;
+
+	@InjectMocks
+	private NotificationAppender notificationAppender;
+
+	@Test
+	@DisplayName("청 사역자에게 알림을 등록할 수 있다.")
+	void append() {
+		// given
+		String writerName = "지창욱";
+		Division daniel = Division.DANIEL;
+
+		// when
+		notificationAppender.append(writerName, daniel);
+
+		// then
+		verify(memberReader, times(1)).findDivisionPastor(any(Division.class));
+		verify(notificationRepository, times(1)).save(any(Notification.class));
+	}
+}

--- a/src/test/java/com/windstorm/management/implement/notification/NotificationModifierTest.java
+++ b/src/test/java/com/windstorm/management/implement/notification/NotificationModifierTest.java
@@ -1,0 +1,38 @@
+package com.windstorm.management.implement.notification;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.windstorm.management.domain.notification.Notification;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationModifierTest {
+	@Mock
+	private NotificationReader notificationReader;
+
+	@InjectMocks
+	private NotificationModifier notificationModifier;
+
+	@Test
+	@DisplayName("알림의 isRead 상태가 false에서 true로 변경된다.")
+	void updateNotificationIsRead() {
+		// given
+		Long id = 1L;
+		Notification notification = mock(Notification.class);
+
+		when(notificationReader.read(any(Long.class))).thenReturn(notification);
+
+		// when
+		notificationModifier.updateIsRead(id);
+
+		// then
+		verify(notificationReader, times(1)).read(any(Long.class));
+		verify(notification, times(1)).updateIsRead();
+	}
+}

--- a/src/test/java/com/windstorm/management/implement/notification/NotificationModifierTest.java
+++ b/src/test/java/com/windstorm/management/implement/notification/NotificationModifierTest.java
@@ -6,16 +6,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.windstorm.management.domain.notification.Notification;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationModifierTest {
-	@Mock
-	private NotificationReader notificationReader;
-
 	@InjectMocks
 	private NotificationModifier notificationModifier;
 
@@ -26,13 +22,10 @@ class NotificationModifierTest {
 		Long id = 1L;
 		Notification notification = mock(Notification.class);
 
-		when(notificationReader.read(any(Long.class))).thenReturn(notification);
-
 		// when
-		notificationModifier.updateIsRead(id);
+		notificationModifier.updateIsRead(notification);
 
 		// then
-		verify(notificationReader, times(1)).read(any(Long.class));
 		verify(notification, times(1)).updateIsRead();
 	}
 }

--- a/src/test/java/com/windstorm/management/implement/notification/NotificationReaderTest.java
+++ b/src/test/java/com/windstorm/management/implement/notification/NotificationReaderTest.java
@@ -1,0 +1,35 @@
+package com.windstorm.management.implement.notification;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.windstorm.management.repository.notification.NotificationRepository;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationReaderTest {
+	@Mock
+	private NotificationRepository notificationRepository;
+
+	@InjectMocks
+	private NotificationReader notificationReader;
+
+	@Test
+	@DisplayName("사역자별로 읽지 않은 알림을 확인할 수 있다.")
+	void read() {
+		// given
+		Long id = 1L;
+
+		// when
+		notificationReader.readBy(id);
+
+		// then
+		verify(notificationRepository, times(1)).findNotificationsByPastor(any(Long.class));
+	}
+
+}

--- a/src/test/java/com/windstorm/management/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/windstorm/management/service/notification/NotificationServiceTest.java
@@ -1,0 +1,85 @@
+package com.windstorm.management.service.notification;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.windstorm.management.api.admin.notification.response.NotificationResponse;
+import com.windstorm.management.domain.global.Division;
+import com.windstorm.management.domain.global.LeaderRole;
+import com.windstorm.management.domain.member.Member;
+import com.windstorm.management.domain.notification.Notification;
+import com.windstorm.management.repository.member.MemberRepository;
+import com.windstorm.management.repository.notification.NotificationRepository;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class NotificationServiceTest {
+	@Autowired
+	private NotificationRepository notificationRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private NotificationService notificationService;
+
+	@AfterEach
+	void cleanUp() {
+		notificationRepository.deleteAll();
+		memberRepository.deleteAll();
+	}
+
+	@Test
+	@DisplayName("사역자가 자신의 청의 읽지 않은 심방 보고서를 조회할 수 있다.")
+	void getNotifications() {
+		// given
+		Member pastor1 = createMember("1", "이준영", Division.DANIEL);
+		Member pastor2 = createMember("2", "김종은", Division.JOSEPH2);
+		memberRepository.save(pastor1);
+		memberRepository.save(pastor2);
+
+		List<Notification> danielNotifications = IntStream.rangeClosed(1, 3)
+			.mapToObj(i ->
+				createNotification(
+					i + "번째 심방 보고서가 등록되었습니다.",
+					pastor1
+				)
+			).toList();
+		notificationRepository.saveAll(danielNotifications);
+
+		// when
+		List<NotificationResponse> result1 = notificationService.getNotifications(pastor1.getUniqueId());
+		List<NotificationResponse> result2 = notificationService.getNotifications(pastor2.getUniqueId());
+
+		// then
+		assertThat(result1).hasSize(3);
+		assertThat(result2).hasSize(0);
+	}
+
+	private Member createMember(String uniqueId, String name, Division division) {
+		return Member.builder()
+			.uniqueId(uniqueId)
+			.name(name)
+			.division(division)
+			.role(LeaderRole.PASTOR)
+			.build();
+	}
+
+	private Notification createNotification(String message, Member member) {
+		return Notification.builder()
+			.message(message)
+			.member(member)
+			.build();
+	}
+}

--- a/src/test/java/com/windstorm/management/service/notification/NotificationServiceTest.java
+++ b/src/test/java/com/windstorm/management/service/notification/NotificationServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.windstorm.management.api.admin.notification.response.NotificationResponse;
 import com.windstorm.management.domain.global.Division;
@@ -65,6 +66,24 @@ class NotificationServiceTest {
 		// then
 		assertThat(result1).hasSize(3);
 		assertThat(result2).hasSize(0);
+	}
+
+	@Test
+	@DisplayName("알림의 읽음 상태가 false에서 true로 업데이트 된다.")
+	@Transactional
+	void updateNotificationIsRead() {
+		// given
+		Member pastor = createMember("1", "이준영", Division.DANIEL);
+		memberRepository.save(pastor);
+
+		Notification notification = createNotification("알림 내용입니다.", pastor);
+		notificationRepository.save(notification);
+
+		// when
+		notificationService.updateNotificationIsRead(notification.getId());
+
+		// then
+		assertThat(notification.isRead()).isTrue();
 	}
 
 	private Member createMember(String uniqueId, String name, Division division) {


### PR DESCRIPTION
### 추가사항
- 리더가 심방보고서를 작성하면 담당 사역자에게 알림이 등록됩니다.
- 사역자는 자신에게 등록된 확인하지 않은 알림을 조회할 수 있습니다.
- 사역자는 알림을 삭제할 수 있습니다.